### PR TITLE
Fix missing use CodeIgniter\Validation\ValidationInterface;

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -3,6 +3,7 @@
 use Config\Services;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Exceptions\ModelException;
+use CodeIgniter\Validation\ValidationInterface;
 use Google\Cloud\Firestore\CollectionReference;
 use Google\Cloud\Firestore\FieldValue;
 use Google\Cloud\Firestore\FirestoreClient;


### PR DESCRIPTION
For Model class's construct. There is no `Tatter\Firebase\ValidationInterface` interface, it should be `CodeIgniter\Validation\ValidationInterface`