### PR TITLE
Super Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,4 @@ This library also comes with its own Firestore `Entity` that handles Google's ti
 conversions and these methods to access metadata about the underlying Firestore document:
 * `document(?DocumentReference $document = null): ?DocumentReference` *Gets or sets the document*
 * `id(): string`
+* `super(): ?DocumentReference` *Gets an Entity's parent Entity, if it is from a subcollection*

--- a/src/Firestore/Entity.php
+++ b/src/Firestore/Entity.php
@@ -7,6 +7,7 @@ use CodeIgniter\I18n\Time;
 use DateTime;
 use Google\Cloud\Core\Timestamp;
 use Google\Cloud\Firestore\DocumentReference;
+use UnexpectedValueException;
 
 class Entity extends FrameworkEntity
 {
@@ -44,6 +45,20 @@ class Entity extends FrameworkEntity
         }
 
         return $this->document;
+    }
+
+    /**
+     * Returns the next higher DocumentReference for nested objects,
+     * or null if not part of a subcollection.
+     */
+    public function super(): ?DocumentReference
+    {
+        if (null === $reference = $this->document()) {
+            throw new UnexpectedValueException('Entity must exist before accessing parent.');
+        }
+
+        // The parent is the subcollection, its parent (if it exists) is a document
+        return $reference->parent()->parent();
     }
 
     /**

--- a/tests/firestore/EntityTest.php
+++ b/tests/firestore/EntityTest.php
@@ -2,6 +2,8 @@
 
 use CodeIgniter\I18n\Time;
 use Google\Cloud\Core\Timestamp;
+use Google\Cloud\Firestore\DocumentReference;
+use Tests\Support\Collections\FruitCollection;
 use Tests\Support\FirestoreTestCase;
 
 /**
@@ -54,5 +56,34 @@ final class EntityTest extends FirestoreTestCase
         $result = $fruit->createdAt;
 
         $this->assertNull($result);
+    }
+
+    public function testSuperRequiresDocument()
+    {
+        $fruit = $this->collection->fake();
+
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('Entity must exist before accessing parent.');
+
+        $this->assertNull($fruit->super());
+    }
+
+    public function testSuperIsNull()
+    {
+        $fruit = $this->collection->make();
+
+        $this->assertNull($fruit->super());
+    }
+
+    public function testSuperReturnsCollectionDocumentParent()
+    {
+        $fruit = $this->collection->make();
+        $foods = collection(FruitCollection::class, $fruit);
+        $food  = $foods->add(['name' => 'food']);
+
+        $result = $food->super();
+
+        $this->assertInstanceOf(DocumentReference::class, $result);
+        $this->assertSame($fruit->id(), $result->id());
     }
 }


### PR DESCRIPTION
Adds `Entity::super()` for accessing the parent document when an Entity is part of a subcollection.